### PR TITLE
fix: Framework v1.3.0 path compatibility

### DIFF
--- a/src/services/healthCheck.ts
+++ b/src/services/healthCheck.ts
@@ -31,7 +31,7 @@ export function runHealthCheck(workspaceRoot: string): HealthResult[] {
     });
   }
 
-  // Policies
+  // Policies — supports both v1.3.0+ and legacy paths
   const policies = [
     '01_Logging_and_RoundTable.md',
     '02_Ticket_and_Briefing.md',
@@ -42,7 +42,9 @@ export function runHealthCheck(workspaceRoot: string): HealthResult[] {
     '07_Parallel_Execution.md',
   ];
 
-  const policyDir = path.join(claudeDir, 'policies');
+  const newPolicyDir = path.join(claudeDir, 'TeamDocument', '1. Policies');
+  const legacyPolicyDir = path.join(claudeDir, 'policies');
+  const policyDir = fs.existsSync(newPolicyDir) ? newPolicyDir : legacyPolicyDir;
   for (const p of policies) {
     results.push({
       category: 'Policies',
@@ -51,22 +53,41 @@ export function runHealthCheck(workspaceRoot: string): HealthResult[] {
     });
   }
 
-  // Team Rosters
-  const rosters = [
-    '1. Team_Overseer.md',
-    '2. Team_Monolith.md',
-    '3. Team_Syndicate.md',
-    '4. Team_Arcade.md',
-    '5. Team_Cipher.md',
-  ];
+  // Team Agents/Rosters — supports both v1.3.0+ and legacy paths
+  const agentsDir = path.join(claudeDir, 'agents');
+  const legacyRosterDir = path.join(claudeDir, 'Team Roster');
+  const useAgents = fs.existsSync(agentsDir);
 
-  const rosterDir = path.join(claudeDir, 'Team Roster');
-  for (const r of rosters) {
-    results.push({
-      category: 'Rosters',
-      item: r,
-      status: fs.existsSync(path.join(rosterDir, r)) ? 'ok' : 'missing',
-    });
+  if (useAgents) {
+    const agents = [
+      'overseer.md',
+      'monolith.md',
+      'syndicate.md',
+      'arcade.md',
+      'cipher.md',
+    ];
+    for (const a of agents) {
+      results.push({
+        category: 'Agents',
+        item: a,
+        status: fs.existsSync(path.join(agentsDir, a)) ? 'ok' : 'missing',
+      });
+    }
+  } else {
+    const rosters = [
+      '1. Team_Overseer.md',
+      '2. Team_Monolith.md',
+      '3. Team_Syndicate.md',
+      '4. Team_Arcade.md',
+      '5. Team_Cipher.md',
+    ];
+    for (const r of rosters) {
+      results.push({
+        category: 'Rosters',
+        item: r,
+        status: fs.existsSync(path.join(legacyRosterDir, r)) ? 'ok' : 'missing',
+      });
+    }
   }
 
   // RoundTable directory

--- a/src/services/policyBrowser.ts
+++ b/src/services/policyBrowser.ts
@@ -10,11 +10,13 @@ export interface PolicyFile {
 }
 
 /**
- * Scan .claude/policies/ for policy markdown files.
- * Returns sorted list with title extracted from first heading.
+ * Scan for policy markdown files.
+ * Supports both v1.3.0+ (.claude/TeamDocument/1. Policies/) and legacy (.claude/policies/).
  */
 export function scanPolicies(workspaceRoot: string): PolicyFile[] {
-  const policyDir = path.join(workspaceRoot, '.claude', 'policies');
+  const newDir = path.join(workspaceRoot, '.claude', 'TeamDocument', '1. Policies');
+  const legacyDir = path.join(workspaceRoot, '.claude', 'policies');
+  const policyDir = fs.existsSync(newDir) ? newDir : legacyDir;
   if (!fs.existsSync(policyDir)) { return []; }
 
   const files = fs.readdirSync(policyDir)

--- a/src/services/rosterViewer.ts
+++ b/src/services/rosterViewer.ts
@@ -18,11 +18,13 @@ export interface TeamRoster {
 }
 
 /**
- * Scan .claude/Team Roster/ for team roster markdown files.
- * Parses the roster table and metadata from each file.
+ * Scan for team roster/agent markdown files.
+ * Supports both v1.3.0+ (.claude/agents/) and legacy (.claude/Team Roster/).
  */
 export function scanRosters(workspaceRoot: string): TeamRoster[] {
-  const rosterDir = path.join(workspaceRoot, '.claude', 'Team Roster');
+  const agentsDir = path.join(workspaceRoot, '.claude', 'agents');
+  const legacyDir = path.join(workspaceRoot, '.claude', 'Team Roster');
+  const rosterDir = fs.existsSync(agentsDir) ? agentsDir : legacyDir;
   if (!fs.existsSync(rosterDir)) { return []; }
 
   const files = fs.readdirSync(rosterDir)


### PR DESCRIPTION
## Summary
- Update 3 service files to support both Framework v1.3.0+ paths and legacy paths
- Automatic detection: if new path exists, use it; otherwise fall back to legacy
- Ensures extension works seamlessly with both old and new framework versions

## Changed Files

| File | Change |
|------|--------|
| `src/services/rosterViewer.ts` | `.claude/agents/` (new) with fallback to `.claude/Team Roster/` (legacy) |
| `src/services/policyBrowser.ts` | `.claude/TeamDocument/1. Policies/` (new) with fallback to `.claude/policies/` (legacy) |
| `src/services/healthCheck.ts` | Both policy and roster/agent paths updated with auto-detection + checks new agent filenames |

## Context
Framework PR #7 (merged into `dev`) restructured:
- `.claude/Team Roster/` → `.claude/agents/`
- `.claude/policies/` → `.claude/TeamDocument/1. Policies/`

Without this fix, Roster Viewer, Policy Browser, and Health Check would show empty/missing data for Framework v1.3.0+ users.

## Type of Change
- [x] Bug fix (non-breaking)

## Checklist
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Backward compatible — works with both old and new framework versions
- [x] No secrets, API keys, or local paths included

## AI Disclosure
- [x] This PR contains AI-generated content (tool: Claude Code / Claude Opus 4.6)

## Test plan
- [ ] Install extension with Framework v1.2.x (legacy paths) → Roster/Policy/Health features work
- [ ] Install extension with Framework v1.3.0+ (new paths) → Roster/Policy/Health features work
- [ ] Install extension with no framework → graceful empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)