### PR TITLE
chore: bump version to v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the RoundTable Hub extension will be documented in this file.
 
+## [1.2.2] - 2026-03-13
+
+### Fixed
+- **Roster Viewer** — now supports Framework v1.3.0 path (`.claude/agents/`) with fallback to legacy (`.claude/Team Roster/`)
+- **Policy Browser** — now supports Framework v1.3.0 path (`.claude/TeamDocument/1. Policies/`) with fallback to legacy (`.claude/policies/`)
+- **Health Check** — auto-detects Framework version and checks correct file paths and names for both v1.3.0+ and legacy
+
+### Changed
+- All 3 services use automatic path detection — fully backward compatible with older Framework versions
+
+---
+
 ## [1.2.1] - 2026-03-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roundtable-hub",
   "displayName": "RoundTable Hub",
   "description": "Management hub for RoundTable Framework — one-click install, visual setup, version management",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publisher": "UnicornTech",
   "license": "MIT",
   "icon": "media/logo3_square.png",


### PR DESCRIPTION
## Summary
- Version bump to v1.2.2 following Framework v1.3.0 path compatibility fix (PR #9)
- CHANGELOG.md updated with v1.2.2 entry

## Type of Change
- [x] Chore (version bump + changelog)

## AI Disclosure
- [x] AI-generated (Claude Code / Claude Opus 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)