### PR TITLE
docs: fix stale URLs and align README with current codebase (MOD-01–03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # UniOpsQC Hub
 
-**Management hub for UniOpsQC Hub Framework** — the multi-team AI governance framework for Claude Code.
+**Management hub for UniOpsQC Framework** — the multi-team AI governance framework for Claude Code.
 
 By [Unicorn Tech Int Co.,Ltd.](https://github.com/VarakornUnicornTech)
 
 ## Features
 
 ### One-Click Install
-Install the RoundTable Framework into any workspace with a single click. Sets up your `.claude/` directory with policies, team rosters, skills, and configuration.
+Install the UniOpsQC Framework into any workspace with a single click. Sets up your `.claude/` directory with policies, team rosters, skills, and configuration.
 
 ### Visual Project Setup
 Configure your `ProjectEnvironment.md` through an interactive wizard — no manual file editing required. Choose project mode (Centralized/Decentralized), set project root, and configure team settings.
@@ -28,13 +28,13 @@ Add, edit, and remove projects through a sidebar form UI instead of editing mark
 Verify framework integrity with a score and detailed file-by-file status report covering core files, policies, and team rosters.
 
 ### Policy Browser (Pro)
-Browse and open all governance policy files directly from the sidebar — quick access to every RoundTable policy section.
+Browse and open all governance policy files directly from the sidebar — quick access to every UniOpsQC policy section.
 
 ### Team Roster Viewer (Pro)
 View all teams, members, roles, and responsibilities in a collapsible tree view. Click through to open the full roster file.
 
 ### Session Statistics (Pro)
-Track your RoundTable session activity with metrics like total sessions, daily averages, activity streaks, and team participation.
+Track your UniOpsQC session activity with metrics like total sessions, daily averages, activity streaks, and team participation.
 
 ### Quick Session Open (Free)
 One-click button to create or open today's RoundTable session file — no manual file navigation needed.
@@ -42,35 +42,52 @@ One-click button to create or open today's RoundTable session file — no manual
 ### Pro License System
 Activate Pro features with a license key from our store. Supports online validation via LemonSqueezy API with offline fallback for uninterrupted work.
 
-## Quick Start
-
-1. Open a workspace in VS Code
-2. Click the RoundTable Hub icon in the Activity Bar
-3. Click **Install RoundTable Framework**
-4. Run **Setup Project** to configure your environment
-
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `RoundTable: Install Framework` | Clone and install the framework into your workspace |
-| `RoundTable: Setup Project` | Configure ProjectEnvironment.md via interactive wizard |
-| `RoundTable: Check for Updates` | Compare local version against latest release |
-| `RoundTable: Update Framework` | Apply framework updates with backup (Pro) |
-
 ## Requirements
 
 - VS Code 1.110.0 or later
 - Git installed and available in PATH
 - Internet connection (for GitHub API access)
 
+## Quick Start
+
+1. Open a workspace in VS Code
+2. Click the **UniOpsQC Hub** icon in the Activity Bar
+3. Click **Install UniOpsQC Framework**
+4. Run **Setup Project** to configure your environment
+
+## Installation
+
+Search for **UniOpsQC Hub** in the VS Code Extensions Marketplace, or install directly via the extension ID:
+
+```
+UnicornTech.roundtable-hub
+```
+
+Or via the VS Code CLI:
+
+```bash
+code --install-extension UnicornTech.roundtable-hub
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `UniOpsQC: Install Framework` | Clone and install the framework into your workspace |
+| `UniOpsQC: Setup Project` | Configure ProjectEnvironment.md via interactive wizard |
+| `UniOpsQC: Check for Updates` | Compare local version against latest release |
+| `UniOpsQC: Update Framework` | Apply framework updates with backup (Pro) |
+| `UniOpsQC: Push to Hub` | Push your project to the connected Hub API (Pro) |
+
 ## Settings
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `roundtable.repoUrl` | `VarakornUnicornTech/unicorn_roundtable_framework_repo` | GitHub repository for the framework template |
+| `roundtable.repoUrl` | `VarakornUnicornTech/UniOpsQC` | GitHub repository for the UniOpsQC Framework template |
 | `roundtable.licenseKey` | (empty) | License key for Pro features |
 | `roundtable.autoCheckUpdates` | `true` | Auto-check for updates on startup |
+| `roundtable.hubApiPath` | (empty) | Path to Hub.Api project for local Hub integration |
+| `roundtable.hubApiUrl` | `http://localhost:5200` | URL of the running Hub API server |
 
 ## Free vs Pro
 
@@ -95,18 +112,22 @@ Activate Pro features with a license key from our store. Supports online validat
 
 ## Get Pro
 
-Upgrade to Pro to unlock the full power of RoundTable Hub — Update Manager, Session Logs, Policy Browser, Team Roster Viewer, Health Check, Statistics, and more.
+Upgrade to Pro to unlock the full power of UniOpsQC Hub — Update Manager, Session Logs, Policy Browser, Team Roster Viewer, Health Check, Statistics, and more.
 
-## About RoundTable Framework
+## About UniOpsQC Framework
 
-RoundTable is a multi-team AI governance framework for Claude Code that enables structured collaboration between specialized AI teams (Overseer, Monolith, Syndicate, Arcade) with built-in policies, logging, and quality assurance.
+UniOpsQC is a multi-team AI governance framework for Claude Code that enables structured collaboration between specialized AI teams (Overseer, Monolith, Syndicate, Arcade) with built-in policies, logging, and quality assurance.
 
-Learn more: [RoundTable Framework on GitHub](https://github.com/VarakornUnicornTech/unicorn_roundtable_framework_repo)
+This extension manages the framework directly from inside VS Code — install, configure, update, and monitor your UniOpsQC setup without leaving the editor.
+
+Learn more: [UniOpsQC Framework on GitHub](https://github.com/VarakornUnicornTech/UniOpsQC)
 
 ## Contributing
 
-Found a bug or have a feature request? [Open an issue](https://github.com/VarakornUnicornTech/roundtable-hub-vscode/issues) on GitHub.
+Found a bug or have a feature request? [Open an issue](https://github.com/VarakornUnicornTech/UniOpsQC-vscode/issues) on GitHub.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines.
 
 ## License
 
-MIT - Unicorn Tech Int Co.,Ltd.
+MIT — Unicorn Tech Int Co.,Ltd.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "icon": "media/logo4.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VarakornUnicornTech/roundtable-hub-vscode"
+    "url": "https://github.com/VarakornUnicornTech/UniOpsQC-vscode"
   },
-  "homepage": "https://github.com/VarakornUnicornTech/roundtable-framework",
+  "homepage": "https://github.com/VarakornUnicornTech/UniOpsQC",
   "engines": {
     "vscode": "^1.110.0"
   },
@@ -80,7 +80,7 @@
       "properties": {
         "roundtable.repoUrl": {
           "type": "string",
-          "default": "VarakornUnicornTech/roundtable-framework",
+          "default": "VarakornUnicornTech/UniOpsQC",
           "description": "GitHub repository for UniOpsQC Framework template"
         },
         "roundtable.licenseKey": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (selection === 'Open Sidebar') {
           vscode.commands.executeCommand('roundtable-hub.sidebar.focus');
         } else if (selection === 'Learn More') {
-          vscode.env.openExternal(vscode.Uri.parse('https://github.com/VarakornUnicornTech/roundtable-framework'));
+          vscode.env.openExternal(vscode.Uri.parse('https://github.com/VarakornUnicornTech/UniOpsQC'));
         }
       });
     }


### PR DESCRIPTION
## Summary
- Fix critical stale URL: `roundtable.repoUrl` default now points to `UniOpsQC` (was `roundtable-framework` — caused 404 on every framework install)
- Fix extension.ts Learn More button URL → correct Framework repo
- README overhaul: align command titles with package.json (`UniOpsQC:` prefix), add missing settings, fix all cross-links, add Marketplace extension ID, update About section

## Tickets
- MOD-01: GitHub repo rename (`roundtable-hub-vscode` → `UniOpsQC-vscode`) ✅
- MOD-02: Source code URL fixes ✅
- MOD-03: README accuracy and professionalism improvements ✅

## Audit
Full documentation audit report: `Development/HubVSCode/08_AuditReport/DOC-AUDIT-01_17-03-2026.md`
Score improved from 6.5/10 → 9.5/10

## RoundTable Governance
- Review: ✅ CLEAN (0 critical, 0 informational)
- Rebased onto origin/dev: ✅
- Tickets verified: MOD-01, MOD-02, MOD-03

---
Shipped via RoundTable governed pipeline