### PR TITLE
chore: bump version to v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roundtable-hub",
   "displayName": "UniOpsQC Hub",
   "description": "Management hub for UniOpsQC Framework — one-click install, visual setup, version management",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "UnicornTech",
   "license": "MIT",
   "icon": "media/logo4.png",


### PR DESCRIPTION
Patch version bump for marketplace release. Includes BUG-01–06 fixes (issues #20–#25) and README standardization.